### PR TITLE
config: Install buster by default

### DIFF
--- a/initramfs/config
+++ b/initramfs/config
@@ -145,7 +145,9 @@ bootstrap() {
     fi
     PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
     export PATH
-    debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,fake-hwclock,mtd-utils,ca-certificates,apt-transport-https,vlan,libnl-3-200,libnl-genl-3-200 stretch $mp http://httpredir.debian.org/debian || exit 1
+    TARGET_RELEASE=buster
+    echo "## Building Debian $TARGET_RELEASE root filesystem..."
+    debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,fake-hwclock,mtd-utils,ca-certificates,apt-transport-https,vlan,libnl-3-200,libnl-genl-3-200 $TARGET_RELEASE $mp http://httpredir.debian.org/debian || exit 1
     return 1
 }
 

--- a/initramfs/keep
+++ b/initramfs/keep
@@ -3,8 +3,8 @@
 
 # Running this script will copy the modules from
 # the in-memory tmpfs filesystem on the root filesystem,
-# and arrange that the tmpfs filesystem is no used in future
-# reboots
+# and arrange that the tmpfs filesystem is not used in
+# future reboots.
 
 keep() {
     mkdir /tmp/modules


### PR DESCRIPTION
Thanks for the excellent `config` script. I used it on a new setup yesterday, but noticed it installed stretch, which is out of support. Here's an update to default to buster (current stable).

This will conflict with the richer support for choosing the target release in #27. I just wanted a safer (and more recent) default.